### PR TITLE
Add Clone function to some storage type to to deep clone the multistore

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -3,6 +3,7 @@ package cachekv
 import (
 	"bytes"
 	"io"
+	"maps"
 	"sort"
 	"sync"
 
@@ -397,5 +398,30 @@ func (store *Store) setCacheValue(key, value []byte, dirty bool) {
 	}
 	if dirty {
 		store.unsortedCache[keyStr] = struct{}{}
+	}
+}
+
+//----------------------------------------
+// fork only
+
+// Clone, a method use to deep clone the state of the Store
+func (store *Store) Clone() types.CacheKVStore {
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
+
+	cache := make(map[string]*cValue, len(store.cache))
+	for k, v := range store.cache {
+		val := *v
+		cache[k] = &val
+	}
+
+	unsortedCache := maps.Clone(store.unsortedCache)
+
+	return &Store{
+		cache:         cache,
+		unsortedCache: unsortedCache,
+		sortedCache:   store.sortedCache.Copy(),
+		// even in a clone the parent should stay the same
+		parent: store.parent,
 	}
 }

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -404,7 +404,7 @@ func (store *Store) setCacheValue(key, value []byte, dirty bool) {
 //----------------------------------------
 // fork only
 
-// Clone, a method use to deep clone the state of the Store
+// Clone, a method used to deep clone the state of the Store
 func (store *Store) Clone() types.CacheKVStore {
 	store.mtx.Lock()
 	defer store.mtx.Unlock()

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -65,6 +65,66 @@ func TestCacheKVStore(t *testing.T) {
 	require.Empty(t, mem.Get(keyFmt(1)), "Expected `key1` to be empty")
 }
 
+func TestClonedCacheKVStore(t *testing.T) {
+	mem := dbadapter.Store{DB: coretesting.NewMemDB()}
+	st := cachekv.NewStore(mem)
+
+	// do some initial setup to the store
+
+	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
+
+	// put something in mem and in cache
+	mem.Set(keyFmt(1), valFmt(1))
+	st.Set(keyFmt(1), valFmt(1))
+	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
+
+	cloned := st.Clone()
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+
+	// update it in cache, shouldn't change mem neither the cloned
+
+	st.Set(keyFmt(1), valFmt(2))
+	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), mem.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+
+	// write it. should change parent but not the
+	// clone
+	st.Write()
+	require.Equal(t, valFmt(2), mem.Get(keyFmt(1)))
+	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+
+	// more writes and checks
+	st.Write()
+	st.Write()
+	require.Equal(t, valFmt(2), mem.Get(keyFmt(1)))
+	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+
+	// // make a new one, check it
+	// st = cachekv.NewStore(mem)
+	// require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+
+	// make a new one and delete - should not be removed from mem
+	st.Delete(keyFmt(1))
+	require.Empty(t, st.Get(keyFmt(1)))
+	require.Equal(t, mem.Get(keyFmt(1)), valFmt(2))
+
+	// Write. should now be removed from both
+	st.Write()
+	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
+	require.Empty(t, mem.Get(keyFmt(1)), "Expected `key1` to be empty")
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+
+	// write the clone. should change parent but not the
+	// original, the deleted key is restored
+	cloned.Write()
+	require.Equal(t, valFmt(1), mem.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
+	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
+}
+
 func TestCacheKVStoreNoNilSet(t *testing.T) {
 	mem := dbadapter.Store{DB: coretesting.NewMemDB()}
 	st := cachekv.NewStore(mem)

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -102,10 +102,6 @@ func TestClonedCacheKVStore(t *testing.T) {
 	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
 	require.Equal(t, valFmt(1), cloned.Get(keyFmt(1)))
 
-	// // make a new one, check it
-	// st = cachekv.NewStore(mem)
-	// require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
-
 	// make a new one and delete - should not be removed from mem
 	st.Delete(keyFmt(1))
 	require.Empty(t, st.Get(keyFmt(1)))

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -167,3 +167,38 @@ func (cms Store) GetKVStore(key types.StoreKey) types.KVStore {
 	}
 	return store.(types.KVStore)
 }
+
+//----------------------------------------
+// fork only
+
+// Clone a method a added to deep clone the state of the Store
+func (cms Store) Clone() types.CacheMultiStore {
+
+	// her based on the following documentation from CacheWrap:
+	// ---
+	// CacheWrap is the most appropriate interface for store ephemeral branching and cache.
+	// For example, IAVLStore.CacheWrap() returns a CacheKVStore. CacheWrap should not return
+	// a Committer, since Commit ephemeral store make no sense. It can return KVStore,
+	// HeapStore, SpaceStore, etc.
+	// ---
+	// We can assument that any of the types behind CacheWrap will implement types.CacheKVStore
+	// because of this, we implement the Clone Method on the CacheKVStore
+	// Which implement both Store and CacheWrapper
+	stores := make(map[types.StoreKey]types.CacheWrap, len(cms.stores))
+	for k, v := range cms.stores {
+		stores[k.Clone()] = v.(types.CacheKVStore).Clone()
+	}
+
+	keys := make(map[string]types.StoreKey, len(cms.stores))
+	for k, v := range cms.keys {
+		keys[k] = v.Clone()
+	}
+
+	return Store{
+		db:           cms.db.Clone(),
+		stores:       stores,
+		keys:         keys,
+		traceWriter:  cms.traceWriter,
+		traceContext: cms.traceContext,
+	}
+}

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -171,25 +171,25 @@ func (cms Store) GetKVStore(key types.StoreKey) types.KVStore {
 //----------------------------------------
 // fork only
 
-// Clone a method a added to deep clone the state of the Store
+// Clone is a method added to deep clone the state of the Store.
 func (cms Store) Clone() types.CacheMultiStore {
 
-	// her based on the following documentation from CacheWrap:
+	// Based on the following documentation from CacheWrap:
 	// ---
 	// CacheWrap is the most appropriate interface for store ephemeral branching and cache.
 	// For example, IAVLStore.CacheWrap() returns a CacheKVStore. CacheWrap should not return
 	// a Committer, since Commit ephemeral store make no sense. It can return KVStore,
 	// HeapStore, SpaceStore, etc.
 	// ---
-	// We can assument that any of the types behind CacheWrap will implement types.CacheKVStore
+	// We can assume that any of the types behind CacheWrap will implement types.CacheKVStore
 	// because of this, we implement the Clone Method on the CacheKVStore
-	// Which implement both Store and CacheWrapper
+	// which implement both Store and CacheWrapper
 	stores := make(map[types.StoreKey]types.CacheWrap, len(cms.stores))
 	for k, v := range cms.stores {
 		stores[k.Clone()] = v.(types.CacheKVStore).Clone()
 	}
 
-	keys := make(map[string]types.StoreKey, len(cms.stores))
+	keys := make(map[string]types.StoreKey, len(cms.keys))
 	for k, v := range cms.keys {
 		keys[k] = v.Clone()
 	}

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -188,7 +188,7 @@ func (cms Store) Clone() types.CacheMultiStore {
 	for k, v := range cms.stores {
 		kvStore, ok := v.(types.CacheKVStore)
 		if !ok {
-			panic("unable to cast types.CacheWrap to types.CacheKVStore, unexpected type stored behing types.CacheWrap")
+			panic("unable to cast types.CacheWrap to types.CacheKVStore, unexpected type stored behind types.CacheWrap")
 		}
 		stores[k.Clone()] = kvStore.Clone()
 	}

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -3,6 +3,7 @@ package cachemulti
 import (
 	"fmt"
 	"io"
+	"maps"
 
 	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/cachekv"
@@ -190,13 +191,17 @@ func (cms Store) Clone() types.CacheMultiStore {
 		if !ok {
 			panic("unable to cast types.CacheWrap to types.CacheKVStore, unexpected type stored behind types.CacheWrap")
 		}
-		stores[k.Clone()] = kvStore.Clone()
+		// we do not Clone k here, because the key use an interface
+		// the map is actually keyed on the address of the interface
+		// cloning would break behaviour
+		stores[k] = kvStore.Clone()
 	}
 
-	keys := make(map[string]types.StoreKey, len(cms.keys))
-	for k, v := range cms.keys {
-		keys[k] = v.Clone()
-	}
+	// here we can clone the map directly
+	//no need to iterate. the values are StoreKey
+	// which we actuall can't clone and need to
+	// use pointe base
+	keys := maps.Clone(cms.keys)
 
 	return Store{
 		db:           cms.db.Clone(),

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -186,7 +186,11 @@ func (cms Store) Clone() types.CacheMultiStore {
 	// which implement both Store and CacheWrapper
 	stores := make(map[types.StoreKey]types.CacheWrap, len(cms.stores))
 	for k, v := range cms.stores {
-		stores[k.Clone()] = v.(types.CacheKVStore).Clone()
+		kvStore, ok := v.(types.CacheKVStore)
+		if !ok {
+			panic("unable to cast types.CacheWrap to types.CacheKVStore, unexpected type stored behing types.CacheWrap")
+		}
+		stores[k.Clone()] = kvStore.Clone()
 	}
 
 	keys := make(map[string]types.StoreKey, len(cms.keys))

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -191,16 +191,15 @@ func (cms Store) Clone() types.CacheMultiStore {
 		if !ok {
 			panic("unable to cast types.CacheWrap to types.CacheKVStore, unexpected type stored behind types.CacheWrap")
 		}
-		// we do not Clone k here, because the key use an interface
-		// the map is actually keyed on the address of the interface
-		// cloning would break behaviour
+		// We do not Clone `k` here, because the key uses an interface.
+		// The map is actually keyed on the address of the interface instance.
+		// Cloning it would break the behavior.
 		stores[k] = kvStore.Clone()
 	}
 
-	// here we can clone the map directly
-	//no need to iterate. the values are StoreKey
-	// which we actuall can't clone and need to
-	// use pointe base
+	// Here we can clone the map directly - no need to iterate. 
+	// The values are `StoreKey` which we actually can't clone
+	// and need to use pointer base.
 	keys := maps.Clone(cms.keys)
 
 	return Store{

--- a/store/cachemulti/store_test.go
+++ b/store/cachemulti/store_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	coretesting "cosmossdk.io/core/testing"
 	"github.com/stretchr/testify/require"
 
+	"cosmossdk.io/store/cachekv"
+	"cosmossdk.io/store/dbadapter"
 	"cosmossdk.io/store/types"
 )
 
@@ -21,4 +24,48 @@ func TestStoreGetKVStore(t *testing.T) {
 
 	require.PanicsWithValue(errMsg,
 		func() { s.GetKVStore(key) })
+}
+
+func bz(s string) []byte  { return []byte(s) }
+func keyFmt(i int) []byte { return bz(fmt.Sprintf("key%0.8d", i)) }
+func valFmt(i int) []byte { return bz(fmt.Sprintf("value%0.8d", i)) }
+
+func TestClonedCacheMultiStore(t *testing.T) {
+	mem := dbadapter.Store{DB: coretesting.NewMemDB()}
+	cacheKV := cachekv.NewStore(mem)
+	key := types.NewKVStoreKey("test")
+	stores := map[types.StoreKey]types.CacheWrapper{
+		key: cacheKV,
+	}
+
+	store := NewFromKVStore(mem, stores, map[string]types.StoreKey{}, nil, nil)
+
+	st := store.GetKVStore(key)
+
+	// do some initial setup to the store
+	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
+
+	// // put something in mem and in cache
+	mem.Set(keyFmt(1), valFmt(1))
+	st.Set(keyFmt(1), valFmt(1))
+	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
+
+	store.Write()
+	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
+
+	cloned := store.Clone()
+	require.Equal(t, valFmt(1), cloned.GetKVStore(key).Get(keyFmt(1)))
+
+	st.Set(keyFmt(1), valFmt(2))
+	require.Equal(t, valFmt(1), cloned.GetKVStore(key).Get(keyFmt(1)))
+
+	store.Write()
+	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+	require.Equal(t, valFmt(1), cloned.GetKVStore(key).Get(keyFmt(1)))
+
+	cloned.GetKVStore(key).Set(keyFmt(1), valFmt(3))
+	store.Write()
+	require.Equal(t, valFmt(2), st.Get(keyFmt(1)))
+	require.Equal(t, valFmt(3), cloned.GetKVStore(key).Get(keyFmt(1)))
+
 }

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -169,6 +169,9 @@ type MultiStore interface {
 type CacheMultiStore interface {
 	MultiStore
 	Write() // Writes operations to underlying KVStore
+
+	// Fork only
+	Clone() CacheMultiStore
 }
 
 // CommitMultiStore is an interface for a MultiStore without cache capabilities.
@@ -290,6 +293,10 @@ type CacheKVStore interface {
 
 	// Write writes operations to underlying KVStore
 	Write()
+
+	// Fork only
+	// Clone the inner cache
+	Clone() CacheKVStore
 }
 
 // CommitKVStore is an interface for MultiStore.
@@ -382,6 +389,8 @@ func (st StoreType) String() string {
 type StoreKey interface {
 	Name() string
 	String() string
+	// Fork only
+	Clone() StoreKey
 }
 
 // CapabilityKey represent the Cosmos SDK keys for object-capability
@@ -545,4 +554,19 @@ func NewMemoryStoreKeys(names ...string) map[string]*MemoryStoreKey {
 	}
 
 	return keys
+}
+
+//----------------------------------------
+// fork only
+
+func (key *MemoryStoreKey) Clone() StoreKey {
+	return &MemoryStoreKey{name: key.name}
+}
+
+func (key *TransientStoreKey) Clone() StoreKey {
+	return &TransientStoreKey{key.name}
+}
+
+func (key *KVStoreKey) Clone() StoreKey {
+	return &KVStoreKey{key.name}
 }

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -389,8 +389,6 @@ func (st StoreType) String() string {
 type StoreKey interface {
 	Name() string
 	String() string
-	// Fork only
-	Clone() StoreKey
 }
 
 // CapabilityKey represent the Cosmos SDK keys for object-capability
@@ -554,19 +552,4 @@ func NewMemoryStoreKeys(names ...string) map[string]*MemoryStoreKey {
 	}
 
 	return keys
-}
-
-//----------------------------------------
-// fork only
-
-func (key *MemoryStoreKey) Clone() StoreKey {
-	return &MemoryStoreKey{name: key.name}
-}
-
-func (key *TransientStoreKey) Clone() StoreKey {
-	return &TransientStoreKey{key.name}
-}
-
-func (key *KVStoreKey) Clone() StoreKey {
-	return &KVStoreKey{key.name}
 }


### PR DESCRIPTION
Related to: https://linear.app/thesis-co/issue/TET-302/proper-revert-mechanism-for-precompiles

### Introduction

This PR introduce a Clone function for the CacheMultiStore and CachKVStore. This are used so when execution precompiles in the mezo codebase, it's possible to beforehand full clone the ongoing cache state and eventually roll it back in case of a revert to the state before the start of the execution of the precompile.

### Changes

Two clone function where added in:
- /store/cachemulti/store.go
- /store/cachekv/store.go
Associated test have been added in the packages

### Author's checklist

- [x] Provided the appropriate description of the pull request
- [x] Updated relevant unit and integration tests
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Assigned myself in the `Assignees` field
- [x] Assigned `mezod-developers` in the `Reviewers` field and notified them on Discord

### Reviewer's checklist

- [x] Confirmed all author's checklist items have been addressed
- [x] Considered security implications of the code changes
- [x] Considered performance implications of the code changes
- [x] Tested the changes and summarized covered scenarios and results in a comment
